### PR TITLE
Use correct kernel arch for ARM platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1230,7 +1230,7 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
-SUBARCH := $(shell uname -m | sed -e s/i.86/i386/)
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/;s/aarch64/arm64/;s/armv.\+/arm/")
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  ?= $(shell uname -r)


### PR DESCRIPTION
Fixed the kernel arch when building on ARM platforms. For example, `aarch64` -> `arm64`.